### PR TITLE
Move compiler to clang-11

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -18,7 +18,7 @@ runs:
           run: echo "cmake_args=${{ env.cmake_args}} -DWITH_COVERAGE=ON" >> $GITHUB_ENV
           shell: bash
         - name: Configure CMake
-          run: cmake -B ${{github.workspace}}/build -G Ninja -DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ env.cmake_args }}
+          run: cmake -B ${{github.workspace}}/build -DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11 -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} ${{ env.cmake_args }}
           shell: bash
         - name: Build
           run: cmake --build ${{github.workspace}}/build --config ${{ inputs.build-type }}


### PR DESCRIPTION
Currently, the repipe on filters does not work in gcc-9. I tried
debugging this for some time but to no avail.

As things work flawlessly across clang versions, let's stick with clang
in the CI for now.