### PR TITLE
Introduce Basic String and Date Types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ set(INCLUDE_H
         "${CMAKE_SOURCE_DIR}/src/codegen/IR.h"
         "${CMAKE_SOURCE_DIR}/src/codegen/IRBuilder.h"
         "${CMAKE_SOURCE_DIR}/src/codegen/Type.h"
+        "${CMAKE_SOURCE_DIR}/src/common/Helpers.h"
         "${CMAKE_SOURCE_DIR}/src/exec/FuseChunk.h"
         "${CMAKE_SOURCE_DIR}/src/exec/PipelineExecutor.h"
         "${CMAKE_SOURCE_DIR}/src/exec/QueryExecutor.h"

--- a/src/algebra/ExpressionOp.cpp
+++ b/src/algebra/ExpressionOp.cpp
@@ -16,13 +16,20 @@ IR::TypeArc ExpressionOp::derive(ComputeNode::Type code, const std::vector<Node*
 }
 
 IR::TypeArc ExpressionOp::derive(ComputeNode::Type code, const std::vector<IR::TypeArc>& types) {
+   // Operations that return a boolean as result.
+   static std::unordered_set<ComputeNode::Type> bool_returning {
+      ComputeNode::Type::Eq, ComputeNode::Type::Neq, 
+      ComputeNode::Type::Less, ComputeNode::Type::LessEqual, 
+      ComputeNode::Type::Greater, ComputeNode::Type::GreaterEqual,
+      ComputeNode::Type::StrEquals
+   };
    if (code == ComputeNode::Type::Hash) {
       return IR::UnsignedInt::build(8);
    }
-   if (code == ComputeNode::Type::Eq || code == ComputeNode::Type::Neq || code == ComputeNode::Type::Less || code == ComputeNode::Type::LessEqual || code == ComputeNode::Type::Greater || code == ComputeNode::Type::GreaterEqual) {
+   if (bool_returning.contains(code)) {
       return IR::Bool::build();
    }
-   // TODO Unify type derivation rules with the raw codegen::Expression.
+   // TODO(benjamin) Unify type derivation rules with the raw codegen::Expression.
    return types[0];
 }
 

--- a/src/algebra/ExpressionOp.h
+++ b/src/algebra/ExpressionOp.h
@@ -45,6 +45,7 @@ struct ExpressionOp : public RelAlgOp {
          Greater,
          GreaterEqual,
          Constant,
+         StrEquals,
       };
 
       // Constructor for regular binary operations.

--- a/src/algebra/suboperators/expressions/ExpressionHelpers.cpp
+++ b/src/algebra/suboperators/expressions/ExpressionHelpers.cpp
@@ -16,7 +16,9 @@ const std::unordered_map<Type, std::string> expr_names{
    {Type::Less, "lt"},
    {Type::LessEqual, "le"},
    {Type::Eq, "eq"},
-   {Type::Neq, "neq"}};
+   {Type::Neq, "neq"},
+   {Type::StrEquals, "streq"}
+};
 
 /// Map from algebra expression types to IR expressions in the jitted code.
 const std::unordered_map<Type, IR::ArithmeticExpr::Opcode> code_map{
@@ -30,6 +32,7 @@ const std::unordered_map<Type, IR::ArithmeticExpr::Opcode> code_map{
    {Type::LessEqual, IR::ArithmeticExpr::Opcode::LessEqual},
    {Type::Eq, IR::ArithmeticExpr::Opcode::Eq},
    {Type::Neq, IR::ArithmeticExpr::Opcode::Neq},
+   {Type::StrEquals, IR::ArithmeticExpr::Opcode::StrEquals}
 };
 
 }

--- a/src/codegen/Expression.h
+++ b/src/codegen/Expression.h
@@ -118,6 +118,8 @@ struct ArithmeticExpr : public BinaryExpr {
       Greater,
       GreaterEqual,
       HashCombine,
+      /// String equals - not really an arithmethic function, but easiest to put here for now.
+      StrEquals,
    };
 
    /// Opcode of this expression.

--- a/src/codegen/Type.h
+++ b/src/codegen/Type.h
@@ -136,6 +136,36 @@ struct Char : public SQLType {
    }
 };
 
+/// Text type. In the engine it is represented as a char* to a 0-terminated string.
+struct String : public SQLType {
+   static TypeArc build() {
+      return std::make_shared<String>();
+   }
+
+   size_t numBytes() const override {
+      return 8;
+   }
+
+   std::string id() const override {
+      return "String";
+   }
+};
+
+/// Date type.
+struct Date : public SQLType {
+   static TypeArc build() {
+      return std::make_shared<Date>();
+   }
+
+   size_t numBytes() const override {
+      return 4;
+   }
+
+   std::string id() const override {
+      return "Date";
+   }
+};
+
 /// Void type which is usually wrapped into pointers for a lack of better options.
 struct Void : public Type {
    static TypeArc build() {
@@ -251,6 +281,10 @@ struct TypeVisitor {
          visitBool(*elem, arg);
       } else if (auto elem = dynamic_cast<const IR::Char*>(&type)) {
          visitChar(*elem, arg);
+      } else if (auto elem = dynamic_cast<const IR::String*>(&type)) {
+         visitString(*elem, arg);
+      } else if (auto elem = dynamic_cast<const IR::Date*>(&type)) {
+         visitDate(*elem, arg);
       } else if (auto elem = dynamic_cast<const IR::ByteArray*>(&type)) {
          visitByteArray(*elem, arg);
       } else if (auto elem = dynamic_cast<const IR::Void*>(&type)) {
@@ -274,6 +308,10 @@ struct TypeVisitor {
    virtual void visitBool(const Bool& type, Arg arg) {}
 
    virtual void visitChar(const Char& type, Arg arg) {}
+
+   virtual void visitString(const String& type, Arg arg) {}
+
+   virtual void visitDate(const Date& type, Arg arg) {}
 
    virtual void visitByteArray(const ByteArray& type, Arg arg) {}
 

--- a/src/interpreter/ExpressionFragmentizer.cpp
+++ b/src/interpreter/ExpressionFragmentizer.cpp
@@ -66,11 +66,26 @@ void ExpressionFragmentizer::fragmentizeHashes()
    }
 }
 
+void ExpressionFragmentizer::fragmentizeFunctions()
+{
+   {
+      // strcmp
+      auto type = IR::String::build();
+      auto& [name, pipe] = pipes.emplace_back();
+      auto& iu_1 = generated_ius.emplace_back(type, "");
+      auto& iu_2 = generated_ius.emplace_back(type, "");
+      auto& iu_out = generated_ius.emplace_back(ExpressionOp::derive(Type::StrEquals, {type, type}), "");
+      auto& op = pipe.attachSuboperator(ExpressionSubop::build(nullptr, {&iu_out}, {&iu_1, &iu_2}, Type::StrEquals));
+      name = op.id();
+   }  
+}
+
 ExpressionFragmentizer::ExpressionFragmentizer()
 {
    fragmentizeBinary();
    fragmentizeCasts();
    fragmentizeHashes();
+   fragmentizeFunctions();
 }
 
 

--- a/src/interpreter/ExpressionFragmentizer.h
+++ b/src/interpreter/ExpressionFragmentizer.h
@@ -14,8 +14,10 @@ struct ExpressionFragmentizer: public Fragmentizer {
    void fragmentizeCasts();
    /// Fragmentize all binary expressions.
    void fragmentizeBinary();
-   /// Fragmentize all hahs expressions.
+   /// Fragmentize all hash expressions.
    void fragmentizeHashes();
+   /// Fragmentize more complex functions such as strcmp.
+   void fragmentizeFunctions();
 
 };
 

--- a/src/interpreter/FragmentGenerator.cpp
+++ b/src/interpreter/FragmentGenerator.cpp
@@ -53,6 +53,9 @@ TypeDecorator& TypeDecorator::attachFloatingPoints() {
 TypeDecorator& TypeDecorator::attachNumeric() {
    attachIntegers();
    attachFloatingPoints();
+   // We also count dates as numeric types. This is because a date internally 
+   // is represented as a 4 byte signed integer (day offset to the epoch).
+   types.push_back(IR::Date::build());
    return *this;
 }
 

--- a/src/interpreter/RuntimeExpressionFragmentizer.cpp
+++ b/src/interpreter/RuntimeExpressionFragmentizer.cpp
@@ -38,6 +38,15 @@ RuntimeExpressionFragmentizer::RuntimeExpressionFragmentizer()
          name = op.id();
       }
    }
+   {
+      // strcmp
+      auto type = IR::String::build();
+      auto& [name, pipe] = pipes.emplace_back();
+      auto& iu_1 = generated_ius.emplace_back(type, "");
+      auto& iu_out = generated_ius.emplace_back(ExpressionOp::derive(Type::StrEquals, {type, type}), "");
+      auto& op = pipe.attachSuboperator(RuntimeExpressionSubop::build(nullptr, {&iu_out}, {&iu_1}, Type::StrEquals, type));
+      name = op.id();
+   }
 }
 
 }


### PR DESCRIPTION
This PR introduces basic string and date type support in inkfuse. Internally, dates are represented as day offset to the epoch 1-1-1970. Strings are just represented as char*.

In terms of function support, the commit introduces the following:
- It adds the required runtime functions for date types
- It adds strcmp for string types, this is enough for most of TPC-H These are already wired up into the primitives for vectorized code generation.

A meta-point: string handling in engines usually is pretty complex. The main challenge is ownership: when do you allocate/deallocate strings that are e.g. created by some regex function?
In inkfuse this is much simpler for now as we don't have functions mutating strings yet. As such, ownership is completely hidden in the storage layer and we just pass strings around.