### PR TITLE
Implement TPC-H Q18

### DIFF
--- a/reproduce/plot.py
+++ b/reproduce/plot.py
@@ -5,6 +5,8 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 
+plt.style.use('ggplot')
+
 systems = ['duckdb', 'umbra_adaptive', 'umbra_optimized', 'inkfuse_fused', 'inkfuse_interpreted', 'inkfuse_hybrid']
 label_map = {
     'duckdb': 'DuckDB',
@@ -27,14 +29,15 @@ if __name__ == '__main__':
             con.execute(f"INSERT INTO results SELECT * FROM read_csv_auto('{f_name}', header=False)")
             con.execute(f"DELETE FROM results WHERE query in ('l_count', 'l_point')")
             # Kinda nasty, change ordering so Q1x come last.
-            con.execute(f"UPDATE results SET query = case when query = 'q14' then 'q9' else query end")
+            con.execute(f"UPDATE results SET query = case when query = 'q14' then 'q8' else query end")
+            con.execute(f"UPDATE results SET query = case when query = 'q18' then 'q9' else query end")
 
-    queries = ['Q1', 'Q3', 'Q4', 'Q6', 'Q14']
+    queries = ['Q1', 'Q3', 'Q4', 'Q6', 'Q14', 'Q18']
 
     # Plot 1: Backends at Different Scale Factors
     fig, axs = plt.subplots(1, 4)
-    fig.set_size_inches(20, 5)
-    x_vals = np.array([0, 1.5, 3, 4.5, 6])
+    fig.set_size_inches(22, 5)
+    x_vals = np.array([0, 1.5, 3, 4.5, 6, 7.5])
     for idx, sf in enumerate(scale_factors):
         offset = -0.5
         for engine in systems:
@@ -43,6 +46,8 @@ if __name__ == '__main__':
                 f"FROM results WHERE sf = '{sf}' and engine = '{engine}' "
                 f"GROUP BY query, engine "
                 f"ORDER BY query").fetchnumpy()
+            if len(res['latency']) != 6:
+                print(f'missing {engine}, {sf}')
             # If we completely cut the x bars it looks like there is no data.
             # Some queries on sf0.01 do take 0 ms (rounded). Put them at 0.5 nevertheless to show there is data.
             # Note that xmax on that plot lies around 50, so this is still representative.
@@ -53,7 +58,7 @@ if __name__ == '__main__':
             axs[idx].set_xlabel('TPC-H Query')
             axs[idx].set_title(f'Scale Factor {sf}')
             offset += 0.2
-    fig.legend(loc='upper center', ncol=len(systems), fancybox=True)
+    fig.legend(loc='upper center', ncol=len(systems), fancybox=False)
     # plt.show()
     os.makedirs('plots', exist_ok=True)
     plt.savefig('plots/main.pdf', bbox_inches='tight', dpi=300)

--- a/reproduce/sql/q18.sql
+++ b/reproduce/sql/q18.sql
@@ -1,0 +1,27 @@
+-- TPC-H Query 18: Simplified Aggregate
+-- If the engine can infer o_orderkey is unique, it can replace
+-- group by keys with any() aggregate function. This plan leads
+-- to much more consistent plans.
+select
+    o_orderkey,
+    sum(l_quantity)
+from
+    customer,
+    orders,
+    lineitem
+where
+        o_orderkey in (
+        select
+            l_orderkey
+        from
+            lineitem
+        group by
+            l_orderkey having
+                sum(l_quantity) > 300
+    )
+  and c_custkey = o_custkey
+  and o_orderkey = l_orderkey
+group by
+    o_orderkey
+limit
+    100

--- a/src/common/TPCH.h
+++ b/src/common/TPCH.h
@@ -26,6 +26,8 @@ std::unique_ptr<Print> q4(const Schema& schema);
 std::unique_ptr<Print> q6(const Schema& schema);
 /// Join (moderate build, moderate probe) ~2x difference
 std::unique_ptr<Print> q14(const Schema& schema);
+/// High cardinality aggregation.
+std::unique_ptr<Print> q18(const Schema& schema);
 
 /// Some interesting custom queries. See /tpch for query text.
 std::unique_ptr<Print> l_count(const Schema& schema);

--- a/test/tpch/test_queries.cpp
+++ b/test/tpch/test_queries.cpp
@@ -35,6 +35,8 @@ const std::unordered_map<std::string, FunctionT> generator_map {
    {"q3", tpch::q3},
    {"q4", tpch::q4},
    {"q6", tpch::q6},
+   {"q14", tpch::q14},
+   {"q18", tpch::q18},
    {"l_count", tpch::l_count},
    {"l_point", tpch::l_point},
 };
@@ -45,6 +47,8 @@ std::unordered_map<std::string, size_t> expected_rows {
    {"q3", 8},
    {"q4", 5},
    {"q6", 1},
+   {"q14", 1},
+   {"q18", 0},
    {"l_count", 1},
    {"l_point", 6},
 };
@@ -65,7 +69,7 @@ INSTANTIATE_TEST_CASE_P(
    tpch_queries,
    TPCHQueriesTestT,
    ::testing::Combine(
-      ::testing::Values("q1", "q3", "q4", "q6", "l_count", "l_point"),
+      ::testing::Values("q1", "q3", "q4", "q6", "q14", "q18", "l_count", "l_point"),
       ::testing::Values(
          PipelineExecutor::ExecutionMode::Fused,
          PipelineExecutor::ExecutionMode::Interpreted,

--- a/tools/inkfuse_bench.cpp
+++ b/tools/inkfuse_bench.cpp
@@ -38,6 +38,7 @@ const std::vector<std::pair<std::string, decltype(tpch::q1)*>> queries = {
    {"q4", tpch::q4},
    {"q6", tpch::q6},
    {"q14", tpch::q14},
+   {"q18", tpch::q18},
    {"l_count", tpch::l_count},
    {"l_point", tpch::l_point},
 };

--- a/tools/inkfuse_runner.cpp
+++ b/tools/inkfuse_runner.cpp
@@ -153,6 +153,10 @@ int main(int argc, char* argv[]) {
                   auto q = tpch::q14(*loaded);
                   runQuery("q14", std::move(q), mode);
                }
+               else if (split[1] == "q18") {
+                  auto q = tpch::q18(*loaded);
+                  runQuery("q18", std::move(q), mode);
+               }
                else if (split[1] == "l_count") {
                   auto q = tpch::l_count(*loaded);
                   runQuery("l_count", std::move(q), mode);
@@ -161,7 +165,7 @@ int main(int argc, char* argv[]) {
                   auto q = tpch::l_point(*loaded);
                   runQuery("l_point", std::move(q), mode);
                } else {
-                  std::cout << "Unrecognized query - we only support {q1, q3, q4, q6, q14, l_count, l_point}\n";
+                  std::cout << "Unrecognized query - we only support {q1, q3, q4, q6, q14, q18, l_count, l_point}\n";
                }
             }
          } else {


### PR DESCRIPTION
This PR Adds TPC-H Q18 to inkfuse. We manage to outperform Umbra, and perform similar to DuckDB.