### PR TITLE
Add ability for reproduction scripts to run up to SF 100

### DIFF
--- a/reproduce/reproduce_all.sh
+++ b/reproduce/reproduce_all.sh
@@ -9,6 +9,7 @@ echo "Reproducing Umbra"
 ./reproduce_umbra.sh 0.1
 ./reproduce_umbra.sh 1
 ./reproduce_umbra.sh 10
+# ./reproduce_umbra.sh 100
 
 # Benchmark DuckDB
 echo "Reproducing DuckDB"
@@ -16,6 +17,7 @@ echo "Reproducing DuckDB"
 ./reproduce_duckdb.py 0.1
 ./reproduce_duckdb.py 1
 ./reproduce_duckdb.py 10
+# ./reproduce_duckdb.py 100
 
 # Benchmark InkFuse
 echo "Reproducing InkFuse"
@@ -23,6 +25,7 @@ echo "Reproducing InkFuse"
 ./reproduce_inkfuse.sh 0.1
 ./reproduce_inkfuse.sh 1
 ./reproduce_inkfuse.sh 10
+# ./reproduce_inkfuse.sh 100
 
 # Feel free to take a look if you want to, but not used in the experimental
 # section of our paper.
@@ -30,6 +33,7 @@ echo "Reproducing InkFuse"
 # ./reproduce_hyperapi 0.1
 # ./reproduce_hyperapi 1
 # ./reproduce_hyperapi 10
+# ./reproduce_hyperapi 100
 
 # Generate Plots
 echo "Generating Plots"

--- a/reproduce/reproduce_umbra.sh
+++ b/reproduce/reproduce_umbra.sh
@@ -31,9 +31,9 @@ fi
 for q in 'q1' 'q3' 'q4' 'q6' 'q14' 'q18'
 do
     # LLVM JIT Compilation
-    COMPILATIONMODE=o ${UMBRA_BIN} umbra_data/tpch_${1} `for i in $(seq 1 10); do echo sql/${q}.sql; done` | grep 'execution' > umbra_data/${q}_a_res_${1}.csv
+    COMPILATIONMODE=o ${UMBRA_BIN} umbra_data/tpch_${1} `for i in $(seq 1 10); do echo sql/${q}.sql; done` | grep 'execution' > umbra_data/${q}_o_res_${1}.csv
     # Adaptive execution using the flying start backend
-    COMPILATIONMODE=a ${UMBRA_BIN} umbra_data/tpch_${1} `for i in $(seq 1 10); do echo sql/${q}.sql; done` | grep 'execution' > umbra_data/${q}_o_res_${1}.csv
+    COMPILATIONMODE=a ${UMBRA_BIN} umbra_data/tpch_${1} `for i in $(seq 1 10); do echo sql/${q}.sql; done` | grep 'execution' > umbra_data/${q}_a_res_${1}.csv
 done
 
 # Post-process umbra dumps


### PR DESCRIPTION
Note that SF 100 requires about 128 GB of RAM (loaded data + memory during query processing). So I am keeping the default at SF 0.01 - SF 10.

Also added a new plot `plot_split_y.py`, which separates Q18 into it's own y-axis ticks. This way the bars for the other systems become easier to read, because they are less compressed.