### PR TITLE
Zero-Copy Scans in the Vectorized Backend

### DIFF
--- a/src/algebra/Pipeline.h
+++ b/src/algebra/Pipeline.h
@@ -64,6 +64,7 @@ struct Pipeline {
    friend class CompilationContext;
    friend class ExecutionContext;
    friend class PipelineRunner;
+   friend class InterpretedRunner;
 
    /// The sub-operators within this pipeline. These are arranged in a topological order of the backing
    /// DAG structure.

--- a/src/algebra/suboperators/IndexedIUProvider.cpp
+++ b/src/algebra/suboperators/IndexedIUProvider.cpp
@@ -8,7 +8,7 @@ const char* IndexedIUProviderState::name = "IndexedIUProviderState";
 
 void IndexedIUProviderRuntime::registerRuntime() {
    RuntimeStructBuilder{IndexedIUProviderState::name}
-      .addMember("start", IR::Pointer::build(IR::Char::build()))
+      .addMember("start", IR::Pointer::build(IR::Pointer::build(IR::Char::build())))
       .addMember("type_param", IR::UnsignedInt::build(8));
 }
 

--- a/src/algebra/suboperators/sources/FuseChunkSource.cpp
+++ b/src/algebra/suboperators/sources/FuseChunkSource.cpp
@@ -54,7 +54,8 @@ void FuseChunkSourceIUProvider::setUpStateImpl(const ExecutionContext& context) 
       auto& state = (*states)[k];
       // Extract the raw data from which to read within the backing chunk.
       auto& col = context.getColumn(**provided_ius.begin(), k);
-      state.start = col.raw_data;
+      // Double indirection: col.raw_data might be rewired during execution.
+      state.start = &col.raw_data;
       if (runtime_params.type_param) {
          // Fetch the underlying raw data from the associated runtime parameters.
          // If the value was hard-coded in the generated code already it will simply never be accessed.

--- a/src/algebra/suboperators/sources/TableScanSource.cpp
+++ b/src/algebra/suboperators/sources/TableScanSource.cpp
@@ -43,7 +43,7 @@ std::string TScanDriver::id() const {
 
 void TScanIUProvider::setUpStateImpl(const ExecutionContext& context) {
    for (auto& state : *states) {
-      state.start = raw_data;
+      state.start = &raw_data;
    }
 }
 

--- a/src/exec/runners/InterpretedRunner.cpp
+++ b/src/exec/runners/InterpretedRunner.cpp
@@ -1,4 +1,5 @@
 #include "InterpretedRunner.h"
+#include "algebra/suboperators/sources/TableScanSource.h"
 #include "interpreter/FragmentCache.h"
 
 namespace inkfuse {
@@ -15,6 +16,76 @@ InterpretedRunner::InterpretedRunner(const Pipeline& backing_pipeline, size_t id
       throw std::runtime_error("No fragment " + fragment_id + " found for interpreted runner.");
    }
    prepared = true;
+
+   if (dynamic_cast<TScanIUProvider*>(op.get())) {
+      // This is actually an IU provider.
+      mode = ExecutionMode::ZeroCopyScan;
+      zero_copy_state = ZeroCopyScanState{
+         .output_iu = op.get()->getIUs().at(0),
+         .type_width = op.get()->getIUs().at(0)->type->numBytes(),
+         .fuse_chunk_ptrs{original_context.getNumThreads()},
+      };
+   }
+}
+
+InterpretedRunner::~InterpretedRunner() {
+   // If we overwrote FuseChunk column pointers restore them now.
+   if (zero_copy_state) {
+      for (size_t thread_id = 0; thread_id < context.getNumThreads(); ++thread_id) {
+         if (zero_copy_state->fuse_chunk_ptrs[thread_id] != nullptr) {
+            context.getColumn(*zero_copy_state->output_iu, thread_id).raw_data = zero_copy_state->fuse_chunk_ptrs[thread_id];
+         }
+      }
+   }
+}
+
+Suboperator::PickMorselResult InterpretedRunner::runMorsel(size_t thread_id, bool force_pick) {
+   // Dispatch to the right interpretation strategy.
+   switch (mode) {
+      case ExecutionMode::DefaultRunMorsel:
+         // Default strategy.
+         return PipelineRunner::runMorsel(thread_id, force_pick);
+      case ExecutionMode::ZeroCopyScan:
+         // Custom zero-copy scan interpreter.
+         return runZeroCopyScan(thread_id, force_pick);
+   }
+}
+
+Suboperator::PickMorselResult InterpretedRunner::runZeroCopyScan(size_t thread_id, bool force_pick) {
+   // The TScanIUProvider used to make a superfluous copy of the table scan source.
+   // We would take the table scan data, and do a contiguous copy of the data into a
+   // FuseChunk.
+   // An alternative is to just take the pointer we get from the table scan morsel
+   // and hook that up as the output of the operation.
+
+   // Only the first TScanIUProvider needs to actually pick the new morsel.
+   // That is marked with `force_pick`. In all other cases assume we already
+   // have a morsel picked.
+   Suboperator::PickMorselResult morsel = Suboperator::PickedMorsel{
+      .morsel_size = 1,
+   };
+   if (force_pick) {
+      morsel = pipe->suboperators[0]->pickMorsel(thread_id);
+      if (std::holds_alternative<Suboperator::NoMoreMorsels>(morsel)) {
+         return morsel;
+      }
+   }
+   if (zero_copy_state->fuse_chunk_ptrs[thread_id] == nullptr) {
+      // Save the raw state of the fuse chunk column. Will be reinstalled on Runner destruction.
+      zero_copy_state->fuse_chunk_ptrs[thread_id] = context.getColumn(*zero_copy_state->output_iu, thread_id).raw_data;
+   }
+   // Get the state of the picked morsel.
+   TScanDriver* driver = dynamic_cast<TScanDriver*>(pipe->suboperators[0].get());
+   TScanIUProvider* provider = dynamic_cast<TScanIUProvider*>(pipe->suboperators[1].get());
+   assert(driver);
+   assert(provider);
+   const auto driver_state = reinterpret_cast<LoopDriverState*>(driver->accessState(thread_id));
+   const auto provider_state = reinterpret_cast<IndexedIUProviderState*>(provider->accessState(thread_id));
+   // And directly update the target fuse chunk column.
+   Column& out_col = context.getColumn(*zero_copy_state->output_iu, thread_id);
+   out_col.size = (driver_state->end - driver_state->start);
+   out_col.raw_data = (*provider_state->start) + (driver_state->start * zero_copy_state->type_width);
+   return morsel;
 }
 
 // static

--- a/src/exec/runners/InterpretedRunner.h
+++ b/src/exec/runners/InterpretedRunner.h
@@ -11,17 +11,44 @@ namespace inkfuse {
 
 /// The pipeline intepreter receives a single pipeline
 struct InterpretedRunner final : public PipelineRunner {
-
    /// Create a pipeline interpreter which will interpret the sub-operator at the given index.
    InterpretedRunner(const Pipeline& backing_pipeline, size_t idx, ExecutionContext& original_context);
+   ~InterpretedRunner();
+
+   /// Run-morsel override. The InterpretedRunner can interpret some morsels without
+   /// actually doing any work.
+   Suboperator::PickMorselResult runMorsel(size_t thread_id, bool force_pick) override;
 
    private:
    /// Get the properly repiped pipeline for the actual execution.
    static PipelinePtr getRepiped(const Pipeline& backing_pipeline, size_t idx);
    /// The fragment id - mainly useful for debugging purposes.
    std::string fragment_id;
-};
 
+   /// How a morsel should be executed.
+   enum class ExecutionMode {
+      /// Default strategy: simply call the precompiled primitive.
+      DefaultRunMorsel,
+      /// Optimized zero-copy path for table scans.
+      ZeroCopyScan,
+   };
+   /// Which execution mode `runMorsel` is bound to.
+   ExecutionMode mode = ExecutionMode::DefaultRunMorsel;
+
+   /// State required to make the zero copy scan work.
+   struct ZeroCopyScanState {
+      // IU being provided by the scan.
+      const IU* output_iu;
+      // Width of the output type.
+      size_t type_width;
+      // Original pointers to the columns in the output FuseChunk. Might be overwritten
+      // and are restored on destruction.
+      std::vector<char*> fuse_chunk_ptrs;
+   };
+   std::optional<ZeroCopyScanState> zero_copy_state;
+   /// Custom interpreter for a zero copy scan.
+   Suboperator::PickMorselResult runZeroCopyScan(size_t thread_id, bool force_pick);
+};
 }
 
 #endif //INKFUSE_PIPELINEINTERPRETER_H

--- a/src/exec/runners/PipelineRunner.h
+++ b/src/exec/runners/PipelineRunner.h
@@ -26,7 +26,7 @@ struct PipelineRunner {
    /// Run a single morsel of the backing pipeline.
    /// @param force_pick should we always pick, even if we are not a fuse chunk source?
    /// @return result of picking a morsel.
-   Suboperator::PickMorselResult runMorsel(size_t thread_id, bool force_pick);
+   virtual Suboperator::PickMorselResult runMorsel(size_t thread_id, bool force_pick);
 
    /// Clean up the intermediate morsel state from a previous failure.
    /// Purges the morsel size of the sinks to make sure we get a fresh


### PR DESCRIPTION
One big disadvantage our vectorized backend had so far was that it could not perform zero-copy table scans. Specifically, our compiling backend scans by directly taking raw pointers from the storage engine and feeding tuples into the computational pipeline through that.

Our vectorized backend meanwhile had to always copy the raw source data into an initial set of FuseChunks. This was an artifact of just interpreting the suboperators one-by-one.

The table scan IU providers would also be interpreted, and perform the initial storage -> fuse chunk copy. Successive vectorized primitives would then always work on top of these initial FuseChunks.

This commit changes the behaviour of the vectorized backend to also be able to scan directly from the storage engine.
This is implemented by changing the `runMorsel` implementation in the `InterpretedRunner` when seeing that we interpret a `TableScanIUProvider`.

In these cases we don't call into the pre-compiled primitive anymore, but rather just rewire pointers from within the FuseChunk sink column to directly point to the picked morsel in the storage engine.

The performance benefits of this approach are substantial. At SF5, we see the following improvements on my development machine:
```
Q1:  111 ms ->  82 ms
Q3:   76 ms ->  71 ms
Q4:   47 ms ->  43 ms
Q6:   31 ms ->  24 ms
Q14:  29 ms ->  16 ms
Q18:  600ms -> 593 ms
```
Unsurprisingly, the benefits are highest in scan-heavy queries.