### PR TITLE
Add Outer Join Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ set(TEST_CC
         "${CMAKE_SOURCE_DIR}/test/runtime/test_hash_table.cpp"
         "${CMAKE_SOURCE_DIR}/test/runtime/test_atomic_hash_table.cpp"
         "${CMAKE_SOURCE_DIR}/test/runtime/test_atomic_hash_table_complex_key.cpp"
+        "${CMAKE_SOURCE_DIR}/test/runtime/test_atomic_hash_table_outer_join.cpp"
         "${CMAKE_SOURCE_DIR}/test/runtime/test_hash_table_complex_key.cpp"
         "${CMAKE_SOURCE_DIR}/test/runtime/test_tuple_materializer.cpp"
         "${CMAKE_SOURCE_DIR}/test/suboperators/test_hash_table_source.cpp"

--- a/reproduce/.gitignore
+++ b/reproduce/.gitignore
@@ -1,5 +1,6 @@
 .idea
 inkfuse_bench
+inkfuse_bench_perf_result*
 hyperd.log
 __pycache__
 data
@@ -9,3 +10,4 @@ result_**
 tpch.hyper
 raw_data
 umbra_data
+mount

--- a/reproduce/analyze_microbenchmark.py
+++ b/reproduce/analyze_microbenchmark.py
@@ -34,32 +34,16 @@ if __name__ == '__main__':
         f"GROUP BY backend, query, sf " \
         f"ORDER BY query")
 
-    con.execute("CREATE TABLE normalizer(query text, tuples int);")
+    con.execute("CREATE TABLE normalizer(query text, tuples bigint);")
 
     # Normalization Factor Calculations - Taking Card. Esimates from Umbra at SF1, and summing
     # up cardinality per relational algebra operator.
-    # Q1: 6 Million for: Scan + Filter + Aggregate
-    # Q3: 7.75 Million for Scans
-    #     7.75 Million for Filters
-    #     4 Million for Joins
-    #     300k for final Agg
-    # Q4: 7.5 Million for Scans
-    #     7.5 Million for Filters
-    #     4 Million for Joins
-    # Q6: 6 Million for Scans
-    #     6 Million for Filters
-    #     200k for final Agg 
-    # Q14: 6.2 Million for Scans
-    #      6 Million for Filters
-    #      250k for Join
-    #      50k for final Agg
-    # Q18: 13.5 Million for Scans
-    #      6 Million for Lineitem Aggregation
-    #      1.5 Million for Filter on Agg result
-    #      1.7 Million for cheap joins
-    #      6 Million for final lineitem join
-    #      200k for final Agg
-    con.execute("INSERT INTO normalizer VALUES ('q1', 18000000), ('q3', 19800000), ('q4', 19000000), ('q6', 12200000), ('q14', 12500000), ('q18', 27900000);")
+    # Q1: 6 Million table scan 
+    # Q3: 8 Million table scan
+    # Q4: 7.5 Million table scan
+    # Q6: 6 Million table scan
+    # Q14: 6.2 Million table scan 
+    con.execute(f"INSERT INTO normalizer VALUES ('q1', {args.scale_factor} * 600000), ('q3', {args.scale_factor} * 800000), ('q4', {args.scale_factor} * 750000), ('q6', {args.scale_factor} * 600000), ('q14', {args.scale_factor} * 620000);")
 
     res = con.execute(
             "SELECT ltrim(backend) as backend, n.query as query, " \

--- a/reproduce/generate_tpch.sh
+++ b/reproduce/generate_tpch.sh
@@ -5,6 +5,11 @@ if [[ $# < 1 ]]; then
   exit 1
 fi
 
+file_shuffle () {
+  shuf $1.tbl > $1_shuffled.tbl
+  mv $1_shuffled.tbl $1.tbl
+}
+
 # Clone TPC-H dbgen tool
 git clone https://github.com/electrum/tpch-dbgen.git
 cd tpch-dbgen
@@ -18,6 +23,16 @@ mkdir -p data
 mv -f tpch-dbgen/*.tbl data
 # Drop tpch-dbgen again
 rm -rf tpch-dbgen
+
+# Shuffle data.
+cd data 
+echo "Shuffling Generated Data"
+file_shuffle "lineitem"
+file_shuffle "orders"
+file_shuffle "partsupp"
+file_shuffle "part"
+file_shuffle "customer"
+cd -
 
 # Normalize data for system ingest
 if [[ $# -ge 2 ]]; then

--- a/reproduce/plot_inkfuse.py
+++ b/reproduce/plot_inkfuse.py
@@ -1,0 +1,89 @@
+#! /usr/bin/python3
+
+import duckdb
+import os
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+
+matplotlib.rcParams.update({'font.size': 24})
+
+systems = ['inkfuse_fused', 'inkfuse_rof', 'inkfuse_interpreted', 'inkfuse_hybrid']
+# Colors of the different systems 
+# DuckDB orange
+# colors = ['#df6f00', '#c5d31f', '#8d9511','#daa6f5','#b056d0', '#782993']
+# DuckDB blue
+colors = ['#daa6f5','#b056d0', '#782993', '#531c66']
+global_hatch = '///'
+
+# Legend labels of the different systems
+label_map = {
+    'inkfuse_fused': 'Compiling',
+    'inkfuse_interpreted': 'Vectorized',
+    'inkfuse_hybrid': 'Hybrid',
+    'inkfuse_rof': 'ROF',
+}
+
+scale_factors = ['100']
+
+if __name__ == '__main__':
+    con = duckdb.connect(database=':memory:')
+    con.execute("CREATE TABLE results (engine text, query text, sf text, latency int, codegen_stalled int);")
+
+    # Insert engine results
+    for engine in systems:
+        for sf in scale_factors:
+            f_name = f'result_{engine}_{sf}.csv'
+            con.execute(f"INSERT INTO results SELECT * FROM read_csv_auto('{f_name}', header=False)")
+            con.execute(f"DELETE FROM results WHERE query in ('l_count', 'l_point', 'q_bigjoin')")
+            # Kinda nasty, change ordering so Q1x come last.
+            con.execute(f"UPDATE results SET query = case when query = 'q13' then 'q87' else query end")
+            con.execute(f"UPDATE results SET query = case when query = 'q14' then 'q88' else query end")
+            con.execute(f"UPDATE results SET query = case when query = 'q18' then 'q98' else query end")
+            con.execute(f"UPDATE results SET query = case when query = 'q19' then 'q99' else query end")
+
+    queries = ['Q1', 'Q3', 'Q4', 'Q5', 'Q6', 'Q14', 'Q19']
+
+    # Plot 1: Backends at Different Scale Factors
+    fig, axs = plt.subplots(1, 1)
+    fig.set_size_inches(16, 5.5)
+    plt.axhline(y=1.0, color='black', linestyle='dashed', linewidth=2.0)
+    plt.set_cmap('Set3')
+    axs.set_ylim(bottom=0.6)
+    axs.set_ylim(top=1.5)
+    x_vals = np.array([0, 1.5, 3, 4.5, 6, 7.5, 9])
+    for idx, sf in enumerate(scale_factors):
+        offset = -0.25
+        for engine_idx, engine in enumerate(systems):
+            # Get the queries with minimal latency for the different queries and engines.
+            res_baseline = con.execute(
+                f"SELECT query, engine, first(latency) as latency, first(codegen_stalled) as codegen_stalled "
+                f"FROM results o WHERE sf = '{sf}' and engine = 'inkfuse_interpreted' "
+                f"  and latency = (SELECT min(latency) FROM results i WHERE sf = '{sf}' and engine = 'inkfuse_interpreted' and i.query = o.query)"
+                f"GROUP BY query, engine "
+                f"ORDER BY query").fetchnumpy()
+            res = con.execute(
+                f"SELECT query, engine, first(latency) as latency, first(codegen_stalled) as codegen_stalled "
+                f"FROM results o WHERE sf = '{sf}' and engine = '{engine}' "
+                f"  and latency = (SELECT min(latency) FROM results i WHERE sf = '{sf}' and engine = '{engine}' and i.query = o.query)"
+                f"GROUP BY query, engine "
+                f"ORDER BY query").fetchnumpy()
+            if len(res['latency']) != 8:
+                print(f'missing {engine}, {sf}')
+            bar_color = len(queries) * [colors[engine_idx]]
+            non_stalled = 1 / ((res['latency'] - res['codegen_stalled'] / 1000) / (res_baseline['latency'] - res_baseline['codegen_stalled'] / 1000))
+            # Seconds
+            # axs.bar(x_vals + offset, stalled, width=0.2, color=bar_color, edgecolor= 'black', hatch = global_hatch)
+            axs.bar(x_vals + offset, non_stalled, width=0.2, label=label_map[engine] if idx == 0 else "", color=bar_color, edgecolor = 'black')
+            axs.set_xticks(x_vals, queries)
+            axs.set_ylabel('Normalized Throughput', fontsize=24)
+            axs.set_title(f'TPC-H Scale Factor {sf}', y=0.88)
+            offset += 0.2
+    # HACK - Add empty bar to just get the legend to contain compliation latency
+    # axs.bar(x_vals + offset - 0.19, [0, 0, 0, 0, 0, 0, 0, 0], bottom=[0, 0, 0, 0, 0, 0, 0, 0], width=0.00001, label='Compilation Latency', hatch = global_hatch, color='white', edgecolor = 'black')
+    fig.legend(loc='upper center', ncol=len(systems) + 1, fancybox=True, labelspacing=0.1, handlelength=1.8, handletextpad=0.4, columnspacing=1.0)
+    # 4. Space legend (actually okay)
+    plt.subplots_adjust(top=0.83)
+    # plt.show()
+    os.makedirs('plots', exist_ok=True)
+    plt.savefig('plots/main_inkfuse.pdf', bbox_inches='tight', dpi=300)

--- a/reproduce/postprocess_umbra.py
+++ b/reproduce/postprocess_umbra.py
@@ -8,7 +8,7 @@ backends = {'a': 'adaptive', 'o': 'optimized'}
 for file in os.listdir('umbra_data'):
     if '_res_' in file:
         print(f'Postprocessing {file}')
-        matched = re.search('^([q0-9]*)_([ao])_res_([0-9.]*).csv', file)
+        matched = re.search('^(q[_a-z0-9]*)_([ao])_res_([0-9.]*).csv', file)
         q_name = matched.group(1)
         mode = matched.group(2)
         sf = matched.group(3).replace('_', '.')

--- a/reproduce/reproduce_umbra.sh
+++ b/reproduce/reproduce_umbra.sh
@@ -28,7 +28,7 @@ if [[ ! -f umbra_data/tpch_${1} ]]; then
 fi
 
 # Run queries
-for q in 'q1' 'q3' 'q4' 'q6' 'q14' 'q18'
+for q in 'q1' 'q3' 'q4' 'q5' 'q6' 'q13' 'q14' 'q18' 'q19' 'q_bigjoin'
 do
     # LLVM JIT Compilation
     COMPILATIONMODE=o ${UMBRA_BIN} umbra_data/tpch_${1} `for i in $(seq 1 10); do echo sql/${q}.sql; done` | grep 'execution' > umbra_data/${q}_o_res_${1}.csv

--- a/reproduce/sql/q13.sql
+++ b/reproduce/sql/q13.sql
@@ -1,0 +1,20 @@
+select
+        c_count,
+        count(*) as custdist
+from
+        (
+                select
+                        c_custkey,
+                        count(o_orderkey)
+                from
+                        customer left outer join orders on
+                                c_custkey = o_custkey
+                                and o_comment not like '%special%requests%'
+                group by
+                        c_custkey
+        ) as c_orders (c_custkey, c_count)
+group by
+        c_count
+order by
+        custdist desc,
+        c_count desc;

--- a/reproduce/sql/q_bigjoin.sql
+++ b/reproduce/sql/q_bigjoin.sql
@@ -1,0 +1,1 @@
+SELECT count(*) FROM lineitem, orders WHERE l_orderkey = o_orderkey

--- a/reproduce/sql/schema.sql
+++ b/reproduce/sql/schema.sql
@@ -69,7 +69,7 @@ create table supplier (
    s_nationkey integer not null,
    s_phone text not null,
    s_acctbal double precision not null,
-   s_comment text not null,
+   s_comment text not null
    -- primary key (s_suppkey)
 );
 
@@ -77,13 +77,13 @@ create table nation (
    n_nationkey integer not null,
    n_name text not null,
    n_regionkey integer not null,
-   n_comment text not null,
+   n_comment text not null
    -- primary key (n_nationkey)
 );
 
 create table region (
    r_regionkey integer not null,
    r_name text not null,
-   r_comment text not null,
+   r_comment text not null
    -- primary key (r_regionkey)
 );

--- a/src/algebra/ExpressionOp.cpp
+++ b/src/algebra/ExpressionOp.cpp
@@ -22,7 +22,7 @@ IR::TypeArc ExpressionOp::derive(ComputeNode::Type code, const std::vector<IR::T
       ComputeNode::Type::Less, ComputeNode::Type::LessEqual,
       ComputeNode::Type::Greater, ComputeNode::Type::GreaterEqual,
       ComputeNode::Type::StrEquals, ComputeNode::Type::And,
-      ComputeNode::Type::Or, ComputeNode::Type::InList};
+      ComputeNode::Type::Or, ComputeNode::Type::InList, ComputeNode::Type::NotLikeTokens};
    if (bool_returning.contains(code)) {
       return IR::Bool::build();
    }
@@ -57,7 +57,7 @@ ExpressionOp::ComputeNode::ComputeNode(IR::TypeArc casted, Node* child)
 }
 
 ExpressionOp::ComputeNode::ComputeNode(Type code_, IR::ValuePtr arg_1, Node* arg_2)
-   : Node(derive(code_, {arg_2})), code(code_), out(output_type), children({arg_2}), opt_runtime_param(std::move(arg_1)) {
+   : Node(derive(code_, {arg_1->getType()})), code(code_), out(output_type), children({arg_2}), opt_runtime_param(std::move(arg_1)) {
    assert(code != Type::Cast);
 }
 

--- a/src/algebra/ExpressionOp.h
+++ b/src/algebra/ExpressionOp.h
@@ -48,6 +48,7 @@ struct ExpressionOp : public RelAlgOp {
          Constant,
          StrEquals,
          InList,
+         NotLikeTokens,
       };
 
       // Constructor for regular binary operations.

--- a/src/algebra/Join.h
+++ b/src/algebra/Join.h
@@ -10,6 +10,7 @@ namespace inkfuse {
 enum class JoinType {
    Inner,
    LeftSemi,
+   LeftOuter,
 };
 
 /// A join in InkFuse. Joins produce very different suboperator DAGs depending on whether

--- a/src/algebra/suboperators/expressions/ExpressionHelpers.cpp
+++ b/src/algebra/suboperators/expressions/ExpressionHelpers.cpp
@@ -7,6 +7,7 @@ namespace ExpressionHelpers {
 const std::unordered_map<Type, std::string> expr_names{
    {Type::Add, "add"},
    {Type::Cast, "cast"},
+   {Type::Constant, "const"},
    {Type::Subtract, "sub"},
    {Type::Multiply, "mul"},
    {Type::Divide, "div"},
@@ -20,6 +21,7 @@ const std::unordered_map<Type, std::string> expr_names{
    {Type::Neq, "neq"},
    {Type::StrEquals, "streq"},
    {Type::InList, "string_in"},
+   {Type::NotLikeTokens, "string_like"},
 };
 
 /// Map from algebra expression types to IR expressions in the jitted code.
@@ -37,9 +39,8 @@ const std::unordered_map<Type, IR::ArithmeticExpr::Opcode> code_map{
    {Type::Or, IR::ArithmeticExpr::Opcode::Or},
    {Type::Neq, IR::ArithmeticExpr::Opcode::Neq},
    {Type::StrEquals, IR::ArithmeticExpr::Opcode::StrEquals},
-   {Type::InList, IR::ArithmeticExpr::Opcode::StrInList}
-};
-
+   {Type::InList, IR::ArithmeticExpr::Opcode::StrInList},
+   {Type::NotLikeTokens, IR::ArithmeticExpr::Opcode::NotLikeTokens}};
 }
 
 }

--- a/src/algebra/suboperators/expressions/RuntimeExpressionSubop.cpp
+++ b/src/algebra/suboperators/expressions/RuntimeExpressionSubop.cpp
@@ -62,14 +62,21 @@ void RuntimeExpressionSubop::consumeAllChildren(CompilationContext& context) {
    }
 
    // Then, compute the expression in the current scope based on the loaded constant.
-   const IR::Stmt& child = context.getIUDeclaration(*source_ius[0]);
-   builder.appendStmt(
-      IR::AssignmentStmt::build(
-         declare,
-         IR::ArithmeticExpr::build(
-            IR::VarRefExpr::build(*rt_c_declare),
-            IR::VarRefExpr::build(child),
-            ExpressionHelpers::code_map.at(type))));
+   if (type == ExpressionOp::ComputeNode::Type::Constant) {
+      builder.appendStmt(
+         IR::AssignmentStmt::build(
+            declare,
+            IR::VarRefExpr::build(*rt_c_declare)));
+   } else {
+      const IR::Stmt& child = context.getIUDeclaration(*source_ius[0]);
+      builder.appendStmt(
+         IR::AssignmentStmt::build(
+            declare,
+            IR::ArithmeticExpr::build(
+               IR::VarRefExpr::build(*rt_c_declare),
+               IR::VarRefExpr::build(child),
+               ExpressionHelpers::code_map.at(type))));
+   }
 
    context.notifyIUsReady(*this);
 }

--- a/src/algebra/suboperators/sources/HashTableSource.h
+++ b/src/algebra/suboperators/sources/HashTableSource.h
@@ -17,13 +17,13 @@ struct HashTableSourceState {
    static void registerRuntime();
 
    /// Backing hash table from which we want to read.
-   void* hash_table;
+   void* hash_table = nullptr;
    /// Iterator pointer at which to start.
-   char* it_ptr_start;
+   char* it_ptr_start = nullptr;
    /// Current iterator index.
    uint64_t it_idx_start;
    /// Iterator pointer at which to end.
-   char* it_ptr_end;
+   char* it_ptr_end = nullptr;
    /// Iterator end index.
    uint64_t it_idx_end;
 };

--- a/src/algebra/suboperators/sources/HashTableSource.h
+++ b/src/algebra/suboperators/sources/HashTableSource.h
@@ -5,6 +5,7 @@
 #include "algebra/RelAlgOp.h"
 #include "algebra/suboperators/Suboperator.h"
 #include "codegen/IRBuilder.h"
+#include "runtime/NewHashTables.h"
 
 namespace inkfuse {
 
@@ -34,6 +35,7 @@ struct HashTableSourceState {
 template <class HashTable>
 struct HashTableSource : public TemplatedSuboperator<HashTableSourceState> {
    static SuboperatorArc build(const RelAlgOp* source, const IU& produced_iu, DefferredStateInitializer* deferred_state_);
+   static SuboperatorArc buildForOuterJoin(const RelAlgOp* source, const IU& produced_iu, const IU& null_marker, DefferredStateInitializer* deferred_state_);
 
    /// Keep running as long as we have cells to read from in the backing hash table.
    PickMorselResult pickMorsel(size_t thread_id) override;
@@ -45,7 +47,7 @@ struct HashTableSource : public TemplatedSuboperator<HashTableSourceState> {
    std::string id() const override;
 
    protected:
-   HashTableSource(const RelAlgOp* source, const IU& produced_iu, DefferredStateInitializer* deferred_state_);
+   HashTableSource(const RelAlgOp* source, const IU& produced_iu, const IU* produced_null_markers, DefferredStateInitializer* deferred_state_);
 
    void setUpStateImpl(const ExecutionContext& context) override;
 
@@ -62,7 +64,7 @@ struct HashTableSource : public TemplatedSuboperator<HashTableSourceState> {
 using SimpleHashTableSource = HashTableSource<HashTableSimpleKey>;
 using ComplexHashTableSource = HashTableSource<HashTableComplexKey>;
 using DirectLookupHashTableSource = HashTableSource<HashTableDirectLookup>;
-
+using AtomicHashTableSource = HashTableSource<AtomicHashTable<SimpleKeyComparator>>;
 }
 
 #endif //INKFUSE_HASHTABLESOURCE_H

--- a/src/codegen/Expression.h
+++ b/src/codegen/Expression.h
@@ -124,6 +124,8 @@ struct ArithmeticExpr : public BinaryExpr {
       StrEquals,
       /// In list with strings - not really an arithmetic function, but easiest to put here for now.
       StrInList,
+      /// Not Like with some tokens - not really an arithmetic function, but easiest to put here for now.
+      NotLikeTokens,
    };
 
    /// Opcode of this expression.

--- a/src/codegen/Type.cpp
+++ b/src/codegen/Type.cpp
@@ -10,7 +10,9 @@ namespace IR {
 void UnsignedInt::print(std::ostream& stream, char* data) const
 {
    if (size == 1) {
-      stream << *reinterpret_cast<uint8_t*>(data);
+      // Need to turn it to uint32_t as otherwise we end up printing the raw byte as ASCII.
+      uint32_t val = *reinterpret_cast<uint8_t*>(data);
+      stream << val;
    } else if (size == 2) {
       stream << *reinterpret_cast<uint16_t*>(data);
    } else if (size == 4) {

--- a/src/codegen/backend_c/BackendC.cpp
+++ b/src/codegen/backend_c/BackendC.cpp
@@ -490,6 +490,10 @@ void BackendC::compileExpression(const IR::Expr& expr, ScopedWriter::Statement& 
             {IR::ArithmeticExpr::Opcode::Eq, "=="},
             {IR::ArithmeticExpr::Opcode::Neq, "!="},
          };
+         static const std::unordered_map<IR::ArithmeticExpr::Opcode, std::string> function_call_map{
+            {IR::ArithmeticExpr::Opcode::StrInList, "in_strlist"},
+            {IR::ArithmeticExpr::Opcode::NotLikeTokens, "not_like_tokens"},
+         };
          if (type.code == IR::ArithmeticExpr::Opcode::StrEquals) {
             // Strcmp needs to return 0 for two strings to be equal.
             stmt.stream() << "(strcmp(";
@@ -497,8 +501,8 @@ void BackendC::compileExpression(const IR::Expr& expr, ScopedWriter::Statement& 
             stmt.stream() << ", ";
             compileExpression(*type.children[1], stmt);
             stmt.stream() << ") == 0)";
-         } else if (type.code == IR::ArithmeticExpr::Opcode::StrInList) {
-             stmt.stream() << "in_strlist(";
+         } else if (function_call_map.contains(type.code)) {
+            stmt.stream() << function_call_map.at(type.code) << "(";
             compileExpression(*type.children[0], stmt);
             stmt.stream() << ", ";
             compileExpression(*type.children[1], stmt);

--- a/src/codegen/backend_c/FunctionsC.cpp
+++ b/src/codegen/backend_c/FunctionsC.cpp
@@ -17,6 +17,28 @@ bool in_strlist(const char* strlist, char* arg) {
     }
     return res;
 }
-)PRE";
 
+bool not_like_tokens(const char* strlist, char* arg) {
+    const struct InLiteralList* literal_list = (const struct InLiteralList*) strlist;
+
+    // Iterate through each token in the literal list
+    for (uint64_t i = 0; i < literal_list->size; i++) {
+        const char* token = literal_list->start[i];
+
+        // Check if the token is found in the argument
+        char* token_in_arg = strstr(arg, token);
+
+        // If the token is not found in the argument, return true 
+        if (token_in_arg == NULL) {
+            return true;
+        }
+
+        // Move the argument pointer to the character after the token
+        arg = token_in_arg + strlen(token);
+    }
+
+    // If all tokens were found in the argument, return false 
+    return false;
+}
+)PRE";
 };

--- a/src/common/TPCH.h
+++ b/src/common/TPCH.h
@@ -26,6 +26,8 @@ std::unique_ptr<Print> q4(const Schema& schema);
 std::unique_ptr<Print> q5(const Schema& schema);
 /// Selective filters
 std::unique_ptr<Print> q6(const Schema& schema);
+/// Outer join customer <-> order
+std::unique_ptr<Print> q13(const Schema& schema);
 /// Join (moderate build, moderate probe) ~2x difference
 std::unique_ptr<Print> q14(const Schema& schema);
 /// High cardinality aggregation.

--- a/src/interpreter/HashTableSourceFragmentizer.cpp
+++ b/src/interpreter/HashTableSourceFragmentizer.cpp
@@ -22,6 +22,13 @@ HashTableSourceFragmentizer::HashTableSourceFragmentizer() {
       auto& op = pipe.attachSuboperator(DirectLookupHashTableSource::build(nullptr, target_iu, nullptr));
       name = op.id();
    }
+   {
+      auto& [name, pipe] = pipes.emplace_back();
+      auto& target_iu = generated_ius.emplace_back(IR::Pointer::build(IR::Char::build()), "");
+      auto& marker_iu = generated_ius.emplace_back(IR::ByteArray::build(5), "");
+      auto& op = pipe.attachSuboperator(AtomicHashTableSource::buildForOuterJoin(nullptr, target_iu, marker_iu, nullptr));
+      name = op.id();
+   }
 }
     
 } // namespace inkfuse

--- a/src/interpreter/RuntimeExpressionFragmentizer.cpp
+++ b/src/interpreter/RuntimeExpressionFragmentizer.cpp
@@ -37,6 +37,15 @@ RuntimeExpressionFragmentizer::RuntimeExpressionFragmentizer()
          auto& op = pipe.attachSuboperator(RuntimeExpressionSubop::build(nullptr, {&iu_out}, {&iu_1}, operation, type));
          name = op.id();
       }
+      // Null map generator.
+      {
+         auto& [name, pipe] = pipes.emplace_back();
+         auto& iu_1 = generated_ius.emplace_back(type, "");
+         auto null_target_type = IR::UnsignedInt::build(1);
+         auto& iu_out = generated_ius.emplace_back(null_target_type);
+         auto& op = pipe.attachSuboperator(RuntimeExpressionSubop::build(nullptr, {&iu_out}, {&iu_1}, Type::Constant, null_target_type));
+         name = op.id();
+      }
    }
    {
       // strcmp
@@ -53,8 +62,18 @@ RuntimeExpressionFragmentizer::RuntimeExpressionFragmentizer()
       auto type = IR::String::build();
       auto& [name, pipe] = pipes.emplace_back();
       auto& iu_1 = generated_ius.emplace_back(type, "");
-      auto& iu_out = generated_ius.emplace_back(ExpressionOp::derive(Type::StrEquals, {type}), "");
+      auto& iu_out = generated_ius.emplace_back(ExpressionOp::derive(Type::InList, {type}), "");
       auto& op = pipe.attachSuboperator(RuntimeExpressionSubop::build(nullptr, {&iu_out}, {&iu_1}, Type::InList, type_runtime_param));
+      name = op.id();
+   }
+   {
+      // like tokens strings
+      auto type_runtime_param = IR::Pointer::build(IR::Char::build());
+      auto type = IR::String::build();
+      auto& [name, pipe] = pipes.emplace_back();
+      auto& iu_1 = generated_ius.emplace_back(type, "");
+      auto& iu_out = generated_ius.emplace_back(ExpressionOp::derive(Type::NotLikeTokens, {type}), "");
+      auto& op = pipe.attachSuboperator(RuntimeExpressionSubop::build(nullptr, {&iu_out}, {&iu_1}, Type::NotLikeTokens, type_runtime_param));
       name = op.id();
    }
 }

--- a/src/runtime/ExternRuntime.cpp
+++ b/src/runtime/ExternRuntime.cpp
@@ -80,6 +80,10 @@ extern "C" uint64_t HashTableRuntime::ht_at_sk_compute_hash_and_prefetch_fixed_4
    return reinterpret_cast<AtomicHashTable<SimpleKeyComparator>*>(table)->compute_hash_and_prefetch_fixed<4>(key);
 }
 
+extern "C" void HashTableRuntime::ht_at_sk_it_advance(void* table, char** it_data, uint64_t* it_idx) {
+   reinterpret_cast<AtomicHashTable<SimpleKeyComparator>*>(table)->iteratorAdvance(it_data, it_idx);
+}
+
 extern "C" uint64_t HashTableRuntime::ht_at_sk_compute_hash_and_prefetch_fixed_8(void* table, char* key) {
    return reinterpret_cast<AtomicHashTable<SimpleKeyComparator>*>(table)->compute_hash_and_prefetch_fixed<8>(key);
 }

--- a/src/runtime/ExternRuntime.h
+++ b/src/runtime/ExternRuntime.h
@@ -34,6 +34,8 @@ extern "C" char* ht_at_sk_lookup(void* table, char* key);
 extern "C" char* ht_at_sk_lookup_disable(void* table, char* key);
 extern "C" char* ht_at_ck_lookup(void* table, char* key);
 
+extern "C" void ht_at_sk_it_advance(void* table, char** it_data, uint64_t* it_idx);
+
 /// Hash/prefetch instructions, fixed width specializations exist.
 extern "C" uint64_t ht_at_sk_compute_hash_and_prefetch(void* table, char* key);
 extern "C" uint64_t ht_at_sk_compute_hash_and_prefetch_fixed_4(void* table, char* key);

--- a/src/runtime/HashTableRuntime.cpp
+++ b/src/runtime/HashTableRuntime.cpp
@@ -101,6 +101,11 @@ void HashTableRuntime::registerRuntime() {
       .addArg("key", IR::Pointer::build(IR::Char::build()))
       .addArg("hash", IR::UnsignedInt::build(8), true);
 
+   RuntimeFunctionBuilder("ht_at_sk_it_advance", IR::Pointer::build(IR::Char::build()))
+      .addArg("table", IR::Pointer::build(IR::Void::build()), true)
+      .addArg("it_data", IR::Pointer::build(IR::Pointer::build(IR::Char::build())))
+      .addArg("it_idx", IR::Pointer::build(IR::UnsignedInt::build(8)));
+
    RuntimeFunctionBuilder("ht_at_ck_compute_hash_and_prefetch", IR::UnsignedInt::build(8))
       .addArg("table", IR::Pointer::build(IR::Void::build()))
       .addArg("key", IR::Pointer::build(IR::Char::build()), true);

--- a/src/runtime/NewHashTables.h
+++ b/src/runtime/NewHashTables.h
@@ -42,6 +42,7 @@ struct AtomicHashTable {
    static const std::string ID;
 
    AtomicHashTable(Comparator comp_, uint16_t total_slot_size_, size_t num_slots_);
+   size_t capacity() const { return num_slots; };
 
    /// Compute the hash for a given key and prefetch the corresponding hash table slot.
    uint64_t compute_hash_and_prefetch(const char* key) const;

--- a/src/runtime/NewHashTables.h
+++ b/src/runtime/NewHashTables.h
@@ -57,6 +57,10 @@ struct AtomicHashTable {
    /// Already requires the hash was computed.
    char* lookup(const char* key, uint64_t hash) const;
    /// Get the pointer to a given key, or nullptr if the group does not exist.
+   /// Already requires the hash was computed.
+   /// Variation for outer joins.
+   char* lookupOuter(const char* key, uint64_t hash) const;
+   /// Get the pointer to a given key, or nullptr if the group does not exist.
    /// If it finds a slot, disables it. Needed for e.g. left semi joins.
    /// Already requires the hash was computed.
    char* lookupDisable(const char* key, uint64_t hash);
@@ -74,12 +78,20 @@ struct AtomicHashTable {
    /// Insert variation when we already computed the hash.
    template <bool copy_only_key = true>
    char* insert(const char* key, uint64_t hash);
+   /// Insert variation when we already computed the hash.
+   template <bool copy_only_key = true>
+   char* insertOuter(const char* key, uint64_t hash);
+
+   /// Hash table outer join iterator for init the HashTableSource.
+   void iteratorStart(char** it_data, size_t* it_idx);
+   /// Hash table outer join iterator advance for the HashTableSource.
+   void iteratorAdvance(char** it_data, size_t* it_idx);
 
    private:
    /// An iterator within the atomic hash table.
    struct IteratorState {
       /// Index in the linear probing hash table.
-      size_t idx;
+      uint64_t idx;
       /// Key.
       char* data_ptr;
       /// Tag.
@@ -90,7 +102,6 @@ struct AtomicHashTable {
    /// Get an iterator to the beginning of the hash table. Points to the first
    /// element in the hash table.
    inline IteratorState itStart() const;
-   /// Advance an iterator within the hash table by one slot.
    /// Advance an iterator within the hash table by one slot.
    inline void itAdvance(IteratorState& it) const;
    /// Advance an iterator within the hash table. Sets the pointer to nullptr when the end of the hash table is reached.

--- a/src/storage/Relation.cpp
+++ b/src/storage/Relation.cpp
@@ -6,6 +6,8 @@ namespace inkfuse {
 
 namespace {
 
+const bool THROW_ON_MISMATCH = false;
+
 void loadDate(char* dest, const char* str) {
    auto val = helpers::dateStrToInt(str);
    *reinterpret_cast<int32_t*>(dest) = val;
@@ -203,7 +205,7 @@ void StoredRelation::loadRow(const std::string& str) {
    }
    // Row is active.
    appendRow();
-   if (currPos != str.length()) {
+   if (THROW_ON_MISMATCH && currPos != str.length()) {
       // There should be a final closing | in the files.
       throw std::runtime_error("Too many columns in TSV");
    }

--- a/test/runtime/test_atomic_hash_table_outer_join.cpp
+++ b/test/runtime/test_atomic_hash_table_outer_join.cpp
@@ -1,0 +1,52 @@
+#include "runtime/NewHashTables.h"
+#include "xxhash.h"
+#include <unordered_set>
+#include <gtest/gtest.h>
+
+namespace inkfuse {
+namespace {
+
+TEST(AtomicComplexHashTableOuterJoin, test_marking) {
+   // ~250k slots
+   SimpleKeyComparator comp(8);
+   AtomicHashTable<SimpleKeyComparator> ht(comp, 16, 1 << 18);
+
+   // Insert 100k keys.
+   for (uint64_t k = 0; k < 100'000; ++k) {
+      const uint64_t hash = ht.compute_hash_and_prefetch_fixed<8>(reinterpret_cast<const char*>(&k));
+      char* key = ht.insertOuter<true>(reinterpret_cast<const char*>(&k), hash);
+   }
+
+   // Lookup every second one.
+   for (uint64_t k = 0; k < 50'000; ++k) {
+      const uint64_t hash = ht.compute_hash_and_prefetch_fixed<8>(reinterpret_cast<const char*>(&k));
+      char* res_1 = ht.lookupOuter(reinterpret_cast<const char*>(&k), hash);
+      char* res_2 = ht.lookupOuter(reinterpret_cast<const char*>(&k), hash);
+      char* res_3 = ht.lookupOuter(reinterpret_cast<const char*>(&k), hash);
+      EXPECT_NE(res_1, nullptr);
+      EXPECT_EQ(res_1, res_2);
+      EXPECT_EQ(res_1, res_3);
+   }
+
+   // Now produce the keys that had no match.
+   char* it_data;
+   uint64_t it_idx;
+   ht.iteratorStart(&it_data, &it_idx);
+   std::unordered_set<uint64_t> non_matches;
+   while (it_data != nullptr) {
+      uint64_t value = *reinterpret_cast<uint64_t*>(it_data);
+      EXPECT_FALSE(non_matches.contains(value));
+      non_matches.insert(value);
+      ht.iteratorAdvance(&it_data, &it_idx);
+   }
+
+   // Make sure we found all non-matches again.
+   EXPECT_EQ(non_matches.size(), 50'000);
+   for (size_t k = 50'000; k < 100'000; k++) {
+      EXPECT_TRUE(non_matches.contains(k));
+   }
+}
+
+} // namespace
+
+} // namespace inkfuse

--- a/test/tpch/test_ingest.cpp
+++ b/test/tpch/test_ingest.cpp
@@ -48,16 +48,6 @@ void testLineitem(Schema& schema) {
          EXPECT_LE(l_shipdate_data[row], max);
       }
    }
-   {
-      // l_comment has 10 <= len <= 44 chars (in the vanilla schema it's VARCHAR(44))
-      auto& l_comment = table->getColumn("l_comment");
-      auto l_comment_data = reinterpret_cast<char**>(l_comment.getRawData());
-      for (size_t row = 0; row < 6005; ++row) {
-         auto len =std::strlen(l_comment_data[row]);
-         EXPECT_GE(len, 10);
-         EXPECT_LE(len, 44);
-      }
-   }
 }
 
 TEST(test_ingest, testdata) {

--- a/test/tpch/test_queries.cpp
+++ b/test/tpch/test_queries.cpp
@@ -80,7 +80,7 @@ INSTANTIATE_TEST_CASE_P(
    tpch_queries,
    TPCHQueriesTestT,
    ::testing::Combine(
-      ::testing::Values("q1", "q3", "q4", "q5", "q6", "q13", "q14", "q18", "q19", "l_count", "q_bigjoin", "l_point"),
+      ::testing::Values("q1", "q3", "q4", "q5", "q6", "q14", "q18", "q19", "l_count", "q_bigjoin", "l_point"),
       ::testing::Values(
          PipelineExecutor::ExecutionMode::Fused,
          PipelineExecutor::ExecutionMode::Interpreted,

--- a/test/tpch/test_queries.cpp
+++ b/test/tpch/test_queries.cpp
@@ -35,6 +35,7 @@ const std::unordered_map<std::string, FunctionT> generator_map{
    {"q4", tpch::q4},
    {"q5", tpch::q5},
    {"q6", tpch::q6},
+   {"q13", tpch::q13},
    {"q14", tpch::q14},
    {"q18", tpch::q18},
    {"q19", tpch::q19},
@@ -51,6 +52,7 @@ std::unordered_map<std::string, size_t> expected_rows{
    // One result for JAPAN
    {"q5", 1},
    {"q6", 1},
+   {"q13", 26},
    {"q14", 1},
    {"q18", 0},
    {"q19", 0},
@@ -78,7 +80,7 @@ INSTANTIATE_TEST_CASE_P(
    tpch_queries,
    TPCHQueriesTestT,
    ::testing::Combine(
-      ::testing::Values("q1", "q3", "q4", "q5", "q6", "q14", "q18", "q19", "l_count", "q_bigjoin", "l_point"),
+      ::testing::Values("q1", "q3", "q4", "q5", "q6", "q13", "q14", "q18", "q19", "l_count", "q_bigjoin", "l_point"),
       ::testing::Values(
          PipelineExecutor::ExecutionMode::Fused,
          PipelineExecutor::ExecutionMode::Interpreted,

--- a/tools/inkfuse_bench.cpp
+++ b/tools/inkfuse_bench.cpp
@@ -44,8 +44,6 @@ const std::vector<std::pair<std::string, decltype(tpch::q1)*>> queries = {
    {"q18", tpch::q18},
    {"q19", tpch::q19},
    {"q_bigjoin", tpch::q_bigjoin},
-   {"l_count", tpch::l_count},
-   {"l_point", tpch::l_point},
 };
 
 /// The execution modes used for benchmarking.

--- a/tools/inkfuse_bench.cpp
+++ b/tools/inkfuse_bench.cpp
@@ -40,8 +40,8 @@ const std::vector<std::pair<std::string, decltype(tpch::q1)*>> queries = {
    {"q4", tpch::q4},
    {"q5", tpch::q5},
    {"q6", tpch::q6},
+   {"q13", tpch::q13},
    {"q14", tpch::q14},
-   {"q18", tpch::q18},
    {"q19", tpch::q19},
    {"q_bigjoin", tpch::q_bigjoin},
 };

--- a/tools/inkfuse_runner.cpp
+++ b/tools/inkfuse_runner.cpp
@@ -189,6 +189,9 @@ int main(int argc, char* argv[]) {
                } else if (split[1] == "q6") {
                   auto q = tpch::q6(*loaded);
                   runQuery("q6", std::move(q), mode, thread_count);
+               } else if (split[1] == "q13") {
+                  auto q = tpch::q13(*loaded);
+                  runQuery("q13", std::move(q), mode, thread_count);
                } else if (split[1] == "q14") {
                   auto q = tpch::q14(*loaded);
                   runQuery("q14", std::move(q), mode, thread_count);
@@ -208,7 +211,7 @@ int main(int argc, char* argv[]) {
                   auto q = tpch::l_point(*loaded);
                   runQuery("l_point", std::move(q), mode, thread_count);
                } else {
-                  std::cout << "Unrecognized query - we only support {q1, q3, q4, q5, q6, q14, q18, q19, l_count, l_point}\n";
+                  std::cout << "Unrecognized query - we only support {q1, q3, q4, q5, q6, q13, q14, q18, q19, l_count, l_point}\n";
                }
             }
          } else {


### PR DESCRIPTION
This PR extends InkFuse with support for left outer joins. We use a dedicates marking bit in the hash table tags to indicate whether a tuple found a join partner.

We then add an additional pipeline that reads from the non-matched tuples in the hash table and produces the null tuples.

We also add support for TPC-H Q13, giving us support for all queries from the original ROF paper now.